### PR TITLE
ChainFury API + fury improvements

### DIFF
--- a/server/api/chatbot.py
+++ b/server/api/chatbot.py
@@ -149,7 +149,7 @@ def delete_chatbot(
         return {"message": "ChatBot not found"}
     chatbot.deleted_at = datetime.now()
     db.commit()
-    return {"msg": "ChatBot deleted successfully"}
+    return {"msg": f"ChatBot '{chatbot.id}' deleted successfully"}
 
 
 # L: GET /chatbot/

--- a/server/api/chatbot.py
+++ b/server/api/chatbot.py
@@ -46,7 +46,7 @@ def create_chatbot(
 
     if chatbot_data.engine not in ChatBotTypes.all():
         resp.status_code = 400
-        return {"message": f"Invalid engine '{chatbot_data.engine}'"}
+        return {"message": f"Invalid engine should be one of {ChatBotTypes.all()}"}
 
     # actually create
     chatbot = ChatBot(

--- a/server/api/chatbot.py
+++ b/server/api/chatbot.py
@@ -3,7 +3,9 @@ from datetime import datetime
 from typing import Annotated, List
 from database import ChatBot, User, ChatBotTypes
 from sqlalchemy.orm import Session
-from fastapi import APIRouter, Depends, Header, Request, Response
+from fastapi import APIRouter, Depends, Header
+from fastapi.requests import Request
+from fastapi.responses import Response
 from pydantic import BaseModel
 from commons.utils import get_user_from_jwt, verify_user, get_user_id_from_jwt
 from commons import config as c
@@ -25,9 +27,9 @@ class ChatBotDetails(BaseModel):
 # C: POST /chatbot/
 @chatbot_router.post("/", status_code=201)
 def create_chatbot(
-    token: Annotated[str, Header()],
     req: Request,
     resp: Response,
+    token: Annotated[str, Header()],
     chatbot_data: ChatBotDetails,
     db: Session = Depends(database.fastapi_db_session),
 ):
@@ -59,35 +61,45 @@ def create_chatbot(
     db.add(chatbot)
     db.commit()
     db.refresh(chatbot)
-    return chatbot.to_dict()
+    return chatbot
 
 
 # R: GET /chatbot/{id}
 @chatbot_router.get("/{id}", status_code=200)
 def get_chatbot(
-    token: Annotated[str, Header()],
     req: Request,
     resp: Response,
+    token: Annotated[str, Header()],
     id: str,
     db: Session = Depends(database.fastapi_db_session),
 ):
+    # validate user
+    username = get_user_from_jwt(token)
+    user = verify_user(db, username)
+
+    # query the db
     chatbot = db.query(ChatBot).filter(ChatBot.id == id, ChatBot.deleted_at == None).first()
     if not chatbot:
         resp.status_code = 404
         return {"message": "ChatBot not found"}
-    return chatbot.to_dict()
+    return chatbot
 
 
 # U: PUT /chatbot/{id}
 @chatbot_router.put("/{id}", status_code=200)
 def update_chatbot(
-    token: Annotated[str, Header()],
     req: Request,
     resp: Response,
+    token: Annotated[str, Header()],
     id: str,
     chatbot_data: ChatBotDetails,
     db: Session = Depends(database.fastapi_db_session),
 ):
+    # validate user
+    username = get_user_from_jwt(token)
+    user = verify_user(db, username)
+
+    # validate chatbot update
     if not len(chatbot_data.update_keys):
         resp.status_code = 400
         return {"message": "No keys to update"}
@@ -98,6 +110,7 @@ def update_chatbot(
         resp.status_code = 400
         return {"message": f"Invalid keys {unq_keys.difference(valid_keys)}"}
 
+    # find and update
     chatbot = db.query(ChatBot).filter(ChatBot.id == id, ChatBot.deleted_at == None).first()
     if not chatbot:
         resp.status_code = 404
@@ -119,43 +132,40 @@ def update_chatbot(
 # D: DELETE /chatbot/{id}
 @chatbot_router.delete("/{id}", status_code=200)
 def delete_chatbot(
-    token: Annotated[str, Header()], req: Request, resp: Response, id: str, db: Session = Depends(database.fastapi_db_session)
+    req: Request,
+    resp: Response,
+    token: Annotated[str, Header()],
+    id: str,
+    db: Session = Depends(database.fastapi_db_session),
 ):
+    # validate user
+    username = get_user_from_jwt(token)
+    user = verify_user(db, username)
+
+    # find and delete
     chatbot = db.query(ChatBot).filter(ChatBot.id == id, ChatBot.deleted_at == None).first()
     if not chatbot:
         resp.status_code = 404
         return {"message": "ChatBot not found"}
     chatbot.deleted_at = datetime.now()
     db.commit()
-    return {"message": "ChatBot deleted successfully"}
+    return {"msg": "ChatBot deleted successfully"}
 
 
 # L: GET /chatbot/
 @chatbot_router.get("/", status_code=200)
-def get_all_chatbots(
-    token: Annotated[str, Header()],
+def list_chatbots(
     req: Request,
     resp: Response,
+    token: Annotated[str, Header()],
     skip: int = 0,
     limit: int = 10,
     db: Session = Depends(database.fastapi_db_session),
 ):
+    # validate user
+    username = get_user_from_jwt(token)
+    user = verify_user(db, username)
+
+    # query the db
     chatbots = db.query(ChatBot).filter(ChatBot.deleted_at == None).offset(skip).limit(limit).all()
-    # return [chatbot.to_dict() for chatbot in chatbots]
-    # ideally this is better solution, but for legacy reasons we are using the below one
-    return {"msg": "success", "chatbots": [chatbot.to_dict() for chatbot in chatbots]}
-
-
-#
-# helpers
-#
-
-
-def db_chatbot_to_api_chatbot(ChatBot) -> ChatBotDetails:
-    return ChatBotDetails(
-        id=ChatBot.id,
-        name=ChatBot.name,
-        dag=ChatBot.dag,
-        created_at=ChatBot.created_at,
-        engine=ChatBot.engine,
-    )
+    return {"chatbots": [chatbot.to_dict() for chatbot in chatbots]}

--- a/server/api/feedback.py
+++ b/server/api/feedback.py
@@ -1,8 +1,12 @@
 import database
 from sqlalchemy.orm import Session
-from fastapi import APIRouter, Depends
+from fastapi.requests import Request
+from fastapi.responses import Response
+from fastapi import APIRouter, Depends, Header
 from pydantic import BaseModel
-from commons.utils import update_chatbot_user_rating
+from typing import Annotated
+
+from commons.utils import update_chatbot_user_rating, get_user_from_jwt, verify_user
 from database_constants import PromptRating
 
 feedback_router = APIRouter(prefix="", tags=["feedback"])
@@ -14,9 +18,16 @@ class FeedbackModel(BaseModel):
 
 @feedback_router.put("/feedback", status_code=200)
 def post_chatbot_user_feedback(
+    req: Request,
+    resp: Response,
+    token: Annotated[str, Header()],
     inputs: FeedbackModel,
     prompt_id: int,
     db: Session = Depends(database.fastapi_db_session),
 ):
+    # validate user
+    username = get_user_from_jwt(token)
+    user = verify_user(db, username)
+
     feedback = update_chatbot_user_rating(db, prompt_id, inputs.score)
-    return {"message": "Chatbot user rating updated", "rating": inputs.score}
+    return {"rating": inputs.score}

--- a/server/api/intermediate_steps.py
+++ b/server/api/intermediate_steps.py
@@ -1,4 +1,7 @@
 from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi.requests import Request
+from fastapi.responses import Response
+
 from sqlalchemy.orm import Session
 from typing import Annotated
 
@@ -9,21 +12,22 @@ from commons.utils import get_user_from_jwt, verify_user
 intermediate_steps_router = APIRouter(prefix="", tags=["intermediate_steps"])
 
 
-@intermediate_steps_router.get("/chatbot/{id}/prompt/{prompt_id}/intermediate_steps", status_code=200)
+@intermediate_steps_router.get("/chatbot/{chatbot_id}/prompt/{prompt_id}/intermediate_steps", status_code=200)
 def get_intermediate_steps(
-    id: str,
-    prompt_id: int,
+    req: Request,
+    resp: Response,
     token: Annotated[str, Header()],
+    chatbot_id: str,
+    prompt_id: int,
     db: Session = Depends(database.fastapi_db_session),
 ):
+    # validate user
     username = get_user_from_jwt(token)
-    verify_user(db, username)
+    user = verify_user(db, username)
+
+    # get intermediate steps
     intermediate_steps = get_prompt_intermediate_data(db, prompt_id)
-    if intermediate_steps is not None:
-        response = {"msg": "success", "data": intermediate_steps}
-    else:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Intermediate steps for the prompt with id {prompt_id} not found",
-        )
-    return response
+    if intermediate_steps is None:
+        resp.status_code = 404
+        return {"msg": "prompt not found"}
+    return {"data": intermediate_steps}

--- a/server/api/prompts.py
+++ b/server/api/prompts.py
@@ -35,7 +35,6 @@ def get_prompt_list(request: Request, chatbot_id: str, limit: int = 100, offset:
         limit = 100
     offset = offset if offset > 0 else 0
     prompts = db.query(PromptModel).filter(PromptModel.chatbot_id == chatbot_id).limit(limit).offset(offset).all()
-    print(prompts)
     return {
         "prompts": [p.to_dict() for p in prompts],
     }
@@ -45,10 +44,10 @@ def get_prompt_list(request: Request, chatbot_id: str, limit: int = 100, offset:
 def process_prompt(request: Request, chatbot_id: str, prompt: Prompt, db: Session = Depends(fastapi_db_session)):
     # result = get_prompt(chatbot_id, prompt, db)
     result = call_engine(chatbot_id, prompt, db)
-    print(result)
+    # print(result)
     # manage any callbacks
-    # ph = get_phandler()
-    # ph.handle(Event(event_type=Event.types.PROCESS_PROMPT, data=result))
+    ph = get_phandler()
+    ph.handle(Event(event_type=Event.types.PROCESS_PROMPT, data=result))
 
     out = result.__dict__
     out.pop("prompt")

--- a/server/commons/utils.py
+++ b/server/commons/utils.py
@@ -1,4 +1,5 @@
 import jwt
+from datetime import datetime, timedelta
 from passlib.hash import sha256_crypt
 from sqlalchemy.exc import IntegrityError
 from database import db_session, User, Prompt, IntermediateStep, Template, ChatBot
@@ -167,12 +168,12 @@ def get_hourly_latency_metrics(db: Session, chatbot_id: str):
     hourly_average_latency = (
         db.query(Prompt)
         .filter(Prompt.chatbot_id == chatbot_id)
+        .filter(Prompt.created_at >= datetime.now() - timedelta(hours=24))
         .with_entities(
             (func.substr(Prompt.created_at, 1, 14)).label("hour"),
             func.avg(Prompt.time_taken).label("avg_time_taken"),
         )
         .group_by((func.substr(Prompt.created_at, 1, 14)))
-        .limit(24)
         .all()
     )
     latency_per_hour = []

--- a/server/components/openai/__init__.py
+++ b/server/components/openai/__init__.py
@@ -1,7 +1,7 @@
 import requests
 from typing import Any, List, Union, Dict
 
-from fury import Secret, model_registry, exponential_backoff
+from fury import Secret, model_registry, exponential_backoff, Model
 
 
 def openai_completion(
@@ -90,11 +90,12 @@ def openai_completion(
 
 
 model_registry.register(
-    fn=openai_completion,
-    collection_name="openai",
-    id="openai-completion",
-    description="Given a prompt, the model will return one or more predicted completions, and can also return the "
-    "probabilities of alternative tokens at each position.",
+    model=Model(
+        collection_name="openai",
+        id="openai-completion",
+        fn=openai_completion,
+        description="Given a prompt, the model will return one or more predicted completions, and can also return the probabilities of alternative tokens at each position.",
+    ),
 )
 
 
@@ -167,8 +168,10 @@ def openai_chat(
 
 
 model_registry.register(
-    fn=openai_chat,
-    collection_name="openai",
-    id="openai-chat",
-    description="Given a list of messages describing a conversation, the model will return a response.",
+    model=Model(
+        collection_name="openai",
+        id="openai-chat",
+        fn=openai_chat,
+        description="Given a list of messages describing a conversation, the model will return a response.",
+    )
 )

--- a/server/components/openai/__init__.py
+++ b/server/components/openai/__init__.py
@@ -95,6 +95,7 @@ model_registry.register(
         id="openai-completion",
         fn=openai_completion,
         description="Given a prompt, the model will return one or more predicted completions, and can also return the probabilities of alternative tokens at each position.",
+        usage=["usage", "total_tokens"],
     ),
 )
 
@@ -173,5 +174,6 @@ model_registry.register(
         id="openai-chat",
         fn=openai_chat,
         description="Given a list of messages describing a conversation, the model will return a response.",
+        usage=["usage", "total_tokens"],
     )
 )

--- a/server/components/stability/__init__.py
+++ b/server/components/stability/__init__.py
@@ -1,6 +1,6 @@
 from typing import List, Dict, Union, Tuple
 
-from fury import Secret, model_registry, exponential_backoff
+from fury import Secret, model_registry, exponential_backoff, Model
 
 
 def stability_text_to_image(
@@ -46,10 +46,12 @@ def stability_text_to_image(
 
 
 model_registry.register(
-    fn=stability_text_to_image,
-    collection_name="stabilityai",
-    id="stability-text-to-image",
-    description="Generate a new image from a text prompt",
+    model=Model(
+        collection_name="stabilityai",
+        id="stability-text-to-image",
+        fn=stability_text_to_image,
+        description="Generate a new image from a text prompt",
+    )
 )
 
 
@@ -92,10 +94,12 @@ def stability_image_to_image(
 
 
 model_registry.register(
-    fn=stability_image_to_image,
-    collection_name="stabilityai",
-    id="stability-image-to-image",
-    description="Modify an image based on a text prompt",
+    model=Model(
+        collection_name="stabilityai",
+        id="stability-image-to-image",
+        fn=stability_image_to_image,
+        description="Modify an image based on a text prompt",
+    )
 )
 
 
@@ -115,13 +119,15 @@ def stability_image_to_image_upscale(stability_api_key: Secret, image: bytes, wi
 
 
 model_registry.register(
-    fn=stability_image_to_image,
-    collection_name="stabilityai",
-    id="stability-image-to-image-upscale",
-    description="Create a higher resolution version of an input image. This operation outputs an image with a maximum pixel "
-    "count of 4,194,304. This is equivalent to dimensions such as 2048x2048 and 4096x1024. By default, the input "
-    "image will be upscaled by a factor of 2. For additional control over the output dimensions, a width or height "
-    "parameter may be specified.",
+    model=Model(
+        collection_name="stabilityai",
+        id="stability-image-to-image-upscale",
+        fn=stability_image_to_image,
+        description="Create a higher resolution version of an input image. This operation outputs an image with a maximum pixel "
+        "count of 4,194,304. This is equivalent to dimensions such as 2048x2048 and 4096x1024. By default, the input "
+        "image will be upscaled by a factor of 2. For additional control over the output dimensions, a width or height "
+        "parameter may be specified.",
+    )
 )
 
 
@@ -166,8 +172,10 @@ def stability_image_to_image_masking(
 
 
 model_registry.register(
-    fn=stability_image_to_image,
-    collection_name="stabilityai",
-    id="stability-image-to-image-masking",
-    description="Selectively modify portions of an image using a mask",
+    model=Model(
+        collection_name="stabilityai",
+        id="stability-image-to-image-masking",
+        fn=stability_image_to_image,
+        description="Selectively modify portions of an image using a mask",
+    )
 )

--- a/server/database_utils/prompt.py
+++ b/server/database_utils/prompt.py
@@ -24,5 +24,4 @@ def create_prompt(db: Session, chatbot_id: str, input_prompt: str, session_id: s
     db.add(db_prompt)
     db.commit()
     db.refresh(db_prompt)
-    print("db_promptdb_promptdb_promptdb_prompt:", db_prompt)
     return db_prompt

--- a/server/fury/agent.py
+++ b/server/fury/agent.py
@@ -49,27 +49,13 @@ class ModelRegistry:
     def has(self, id: str):
         return id in self.models
 
-    def register(
-        self,
-        fn: object,
-        collection_name: str,
-        id: str,
-        description: str,
-        tags: List[str] = [],
-    ):
-        id = f"{id}"
+    def register(self, model: Model):
+        id = f"{model.id}"
         logger.debug(f"Registering model {id} at {id}")
         if id in self.models:
             raise Exception(f"Model {id} already registered")
-        self.models[id] = Model(
-            collection_name=collection_name,
-            id=id,
-            fn=fn,
-            description=description,
-            vars=func_to_vars(fn),
-            tags=tags,
-        )
-        for tag in tags:
+        self.models[id] = model
+        for tag in model.tags:
             self.tags_to_models[tag] = self.tags_to_models.get(tag, []) + [id]
 
     def get_tags(self) -> List[str]:

--- a/server/fury/base.py
+++ b/server/fury/base.py
@@ -461,14 +461,14 @@ class Model:
         id,
         fn: object,
         description,
-        vars: List[Var],
         tags=[],
     ):
         self.collection_name = collection_name
         self.id = id
         self.fn = fn
+        # vars: List[Var],
         self.description = description
-        self.vars = vars
+        self.vars = func_to_vars(fn)
         self.tags = tags
 
     def __repr__(self) -> str:

--- a/server/fury/base.py
+++ b/server/fury/base.py
@@ -461,13 +461,14 @@ class Model:
         id,
         fn: object,
         description,
+        usage: List[Union[str, int]] = [],
         tags=[],
     ):
         self.collection_name = collection_name
         self.id = id
         self.fn = fn
-        # vars: List[Var],
         self.description = description
+        self.usage = usage
         self.vars = func_to_vars(fn)
         self.tags = tags
 
@@ -479,8 +480,9 @@ class Model:
             "collection_name": self.collection_name,
             "id": self.id,
             "description": self.description,
-            "tags": self.tags,
+            "usage": self.usage,
             "vars": [x.to_dict() for x in self.vars] if not no_vars else [],
+            "tags": self.tags,
         }
 
     def __call__(self, model_data: Dict[str, Any]) -> Tuple[Any, Optional[Exception]]:

--- a/server/plugins/handler.py
+++ b/server/plugins/handler.py
@@ -29,7 +29,6 @@ class PluginHandler:
                 ph.handle(event)
             except Exception as e:
                 logger.error(f"Error handling event {event.event_type} with plugin {pname}")
-                raise e
 
 
 @lru_cache(1)

--- a/server/stories/api.py
+++ b/server/stories/api.py
@@ -81,7 +81,7 @@ class ChatbotAPI:
         # fmt: off
         hr("Create chatbot"); out = self.init(name); print("New chatbot:", out)
         hr("List chatbots"); chatbots = self.list()["chatbots"]; print("total chatbots:", len(chatbots))
-        hr("Show chatbot"); out = self.show(chatbots[0]["id"]); print("chatbot:", out)
+        hr("Show chatbot"); out = self.show(out["id"]); print("chatbot:", out)
         hr("Update chatbot"); out = self.update(out["id"], name="new name"); print("updated chatbot:", out)
         hr("Delete chatbot"); out = self.delete(out["id"]); print("deleted chatbot:", out)
         hr("List chatbots"); out = self.list(); print("total chatbots:", len(out))


### PR DESCRIPTION
- api: latency metrics returns for last 24 hours
- api: add some standardisation:
  - all the server side messages are in `msg` key now
  - APIs only return the data or message, not both
- api: all APIs are now authenticated

- fury: register models directly instead of passing arguments
- fury: add field for tracking usage

- code: all apis are black formatted